### PR TITLE
SSDP Fix

### DIFF
--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -272,22 +272,24 @@ namespace Jellyfin.Server
                         {
                             _logger.LogInformation("Kestrel listening on {IpAddress}", address);
                             options.Listen(address, appHost.HttpPort);
-
-                            if (appHost.EnableHttps && appHost.Certificate != null)
+                            if (appHost.EnableHttps)
                             {
-                                options.Listen(address, appHost.HttpsPort, listenOptions =>
+                                if (appHost.Certificate != null)
                                 {
-                                    listenOptions.UseHttps(appHost.Certificate);
-                                    listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
-                                });
-                            }
-                            else if (builderContext.HostingEnvironment.IsDevelopment())
-                            {
-                                options.Listen(address, appHost.HttpsPort, listenOptions =>
+                                    options.Listen(address, appHost.HttpsPort, listenOptions =>
+                                    {
+                                        listenOptions.UseHttps(appHost.Certificate);
+                                        listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
+                                    });
+                                }
+                                else if (builderContext.HostingEnvironment.IsDevelopment())
                                 {
-                                    listenOptions.UseHttps();
-                                    listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
-                                });
+                                    options.Listen(address, appHost.HttpsPort, listenOptions =>
+                                    {
+                                        listenOptions.UseHttps();
+                                        listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
+                                    });
+                                }
                             }
                         }
                     }
@@ -296,21 +298,24 @@ namespace Jellyfin.Server
                         _logger.LogInformation("Kestrel listening on all interfaces");
                         options.ListenAnyIP(appHost.HttpPort);
 
-                        if (appHost.EnableHttps && appHost.Certificate != null)
+                        if (appHost.EnableHttps)
                         {
-                            options.ListenAnyIP(appHost.HttpsPort, listenOptions =>
+                            if (appHost.Certificate != null)
                             {
-                                listenOptions.UseHttps(appHost.Certificate);
-                                listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
-                            });
-                        }
-                        else if (builderContext.HostingEnvironment.IsDevelopment())
-                        {
-                            options.ListenAnyIP(appHost.HttpsPort, listenOptions =>
+                                options.ListenAnyIP(appHost.HttpsPort, listenOptions =>
+                                {
+                                    listenOptions.UseHttps(appHost.Certificate);
+                                    listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
+                                });
+                            }
+                            else if (builderContext.HostingEnvironment.IsDevelopment())
                             {
-                                listenOptions.UseHttps();
-                                listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
-                            });
+                                options.ListenAnyIP(appHost.HttpsPort, listenOptions =>
+                                {
+                                    listenOptions.UseHttps();
+                                    listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
+                                });
+                            }
                         }
                     }
                 })


### PR DESCRIPTION
Whilst fixing issues with SSDP on devices with multiple interfaces, i came across a design issue in the current code - namely interfaces without a gateway were ignored.

Removing this also removed the attempt to detect virtual interfaces - so i implemented a work around solution (see 4 below) to keep the functionality.

Whilst in the area, I also fixed a few minor bugs i encountered (1, 5, 6 below) and stopped SSDP messages from going out on non-LAN interfaces (3)

All these changes are related.

Changes

IsInPrivateAddressSpace - improved subnet code checking
interfaces with no gateway were being excluded from SSDP blasts
filtered SSDP blasts from not LAN addresses as defined on the network page.
removed jellyfin#986 mod - as this was part of the issue of jellyfin#2986. Interfaces can be excluded from the LAN by putting the LAN address in brackets. eg. [10.1.1.1] will exclude an interface with ip address 10.1.1.1 from SSDP
fixed a problem where an invalid LAN address causing the SSDP to crash
corrected local link filter (FilterIPAddress) to filter on 169.254. addresses